### PR TITLE
fix(request): return correct remote_addr using trusted_proxies...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+06-21-18 1.5.5:
+
+Fix request.remote_addr logic to return the correct, first untrusted
+address.
+
 06-11-18 1.5.4:
 
 Re-Fix AttributeError: 'NoneType' object has no attribute 'read'.

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 if __name__ == '__main__':
     setup(
         name='powernap',
-        version='1.5.4',
+        version='1.5.5',
         author='Zachary Kazanski',
         author_email='kazanski.zachary@gmail.com',
         description='Framework for quickly buidling REST-ful APIs in Flask.',


### PR DESCRIPTION
The code had a mistake `if ip in trusted_proxies` rather than `if ip in proxy`
which caused that line to always return False meaning the first ip address would
always fall through to the `return str(ip)` line. If the line is fixed, it would
return `None` as it would fall out of the loop and the implicit `return None`
would occur. This logic does not match the logic referenced in the StackOverflow
link.

New, Current Logic:
- go through each address in reverse starting with remote_addr
- Return the first untrusted address, i.e. not contained in any trusted proxy
  networks
- If all addresses are trusted, return remote_addr