### PR TITLE
fix(exceptions): Subclassed exceptions now pass arguments to base classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+01-23-19 2.2.3:
+
+Pass custom exception arguments to base classes so we get messages in the logs.
+
 10-23-18 2.2.2:
 
 Add an ugly request rate limiting hack for admins to prevent crashing.

--- a/powernap/exceptions.py
+++ b/powernap/exceptions.py
@@ -12,7 +12,7 @@ from powernap.http_codes import (
 class ApiError(Exception):
     """Triggers Flask error handler :meth:`core.api.exceptions.api_error`."""
 
-    def __init__(self, description=None):
+    def __init__(self, *args, description=None, **kwargs):
         """Create an ApiError with an optional description.
 
         :param description: A json serializable object or data structure
@@ -20,7 +20,7 @@ class ApiError(Exception):
             the key `errors`.
         """
         self.description = description
-        super(Exception, self).__init__()
+        super().__init__(*args, **kwargs)
 
 
 class InvalidFormError(ApiError):

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 if __name__ == '__main__':
     setup(
         name='powernap',
-        version='2.2.2',
+        version='2.2.3',
         author='Zachary Kazanski',
         author_email='kazanski.zachary@gmail.com',
         description='Framework for quickly buidling REST-ful APIs in Flask.',


### PR DESCRIPTION
This fixes it so we see our exception messages in the logs. Before,
`str(exc_instance) == ''`